### PR TITLE
feat: tensorrt engine support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,64 @@ project(autoware_diffusion_planner)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# Options
+option(CUDA_VERBOSE "Verbose output of CUDA modules" OFF)
+
+# Find CUDA
+option(CUDA_AVAIL "CUDA available" OFF)
+find_package(CUDA)
+if(CUDA_FOUND)
+  find_library(CUBLAS_LIBRARIES cublas HINTS
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib
+  )
+  if(CUDA_VERBOSE)
+    message(STATUS "CUDA is available!")
+    message(STATUS "CUDA Libs: ${CUDA_LIBRARIES}")
+    message(STATUS "CUDA Headers: ${CUDA_INCLUDE_DIRS}")
+  endif()
+  unset(CUDA_cublas_device_LIBRARY CACHE)
+  set(CUDA_AVAIL ON)
+else()
+  message(WARNING "CUDA NOT FOUND")
+  set(CUDA_AVAIL OFF)
+endif()
+
+# Find TensorRT libraries
+option(TRT_AVAIL "TensorRT available" OFF)
+find_library(NVINFER nvinfer)
+find_library(NVONNXPARSER nvonnxparser)
+if(NVINFER AND NVONNXPARSER)
+  if(CUDA_VERBOSE)
+    message(STATUS "TensorRT is available!")
+    message(STATUS "NVINFER: ${NVINFER}")
+    message(STATUS "NVONNXPARSER: ${NVONNXPARSER}")
+  endif()
+  set(TRT_AVAIL ON)
+else()
+  message(WARNING "TensorRT is NOT Available")
+  set(TRT_AVAIL OFF)
+endif()
+
+# Find CUDNN library (optional, often used with TRT)
+option(CUDNN_AVAIL "CUDNN available" OFF)
+find_library(CUDNN_LIBRARY
+  NAMES libcudnn.so
+  PATHS $ENV{LD_LIBRARY_PATH} ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+  DOC "CUDNN library."
+)
+if(CUDNN_LIBRARY)
+  if(CUDA_VERBOSE)
+    message(STATUS "CUDNN is available!")
+    message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
+  endif()
+  set(CUDNN_AVAIL ON)
+else()
+  message(WARNING "CUDNN is NOT Available")
+  set(CUDNN_AVAIL OFF)
+endif()
+
+# ONNX Runtime (your existing)
 option(ONNXRUNTIME_DIR "Path to ONNX Runtime install root" "$ENV{HOME}/onnxruntime-linux-x64-gpu-1.20.1")
 set(ONNXRUNTIME_INCLUDE_DIR "${ONNXRUNTIME_DIR}/include")
 set(ONNXRUNTIME_LIB "${ONNXRUNTIME_DIR}/lib/libonnxruntime.so")
@@ -17,6 +75,10 @@ include_directories(
   ${ONNXRUNTIME_INCLUDE_DIR}
 )
 
+# Add compile option to suppress deprecation warnings (optional)
+add_compile_options(-Wno-deprecated-declarations)
+
+# Add your component library
 ament_auto_add_library(autoware_diffusion_planner_component SHARED
   src/diffusion_planner_node.cpp
   src/conversion/lanelet.cpp
@@ -30,10 +92,28 @@ ament_auto_add_library(autoware_diffusion_planner_component SHARED
   src/utils/marker_utils.cpp
 )
 
+# Link libraries for ONNX Runtime, CUDA, TensorRT as available
 target_link_libraries(autoware_diffusion_planner_component
   ${ONNXRUNTIME_LIB}
 )
 
+if(TRT_AVAIL AND CUDA_AVAIL)
+  target_include_directories(autoware_diffusion_planner_component PUBLIC
+    ${CUDA_INCLUDE_DIRS}
+  )
+  target_link_libraries(autoware_diffusion_planner_component
+    ${NVINFER}
+    ${NVONNXPARSER}
+    ${CUDA_LIBRARIES}
+    ${CUBLAS_LIBRARIES}
+  )
+endif()
+
+if(CUDNN_AVAIL)
+  target_link_libraries(autoware_diffusion_planner_component
+    ${CUDNN_LIBRARY}
+  )
+endif()
 
 rclcpp_components_register_node(autoware_diffusion_planner_component
   PLUGIN "autoware::diffusion_planner::DiffusionPlanner"
@@ -42,18 +122,17 @@ rclcpp_components_register_node(autoware_diffusion_planner_component
 
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_diffusion_planner
-  tests/agent_test.cpp
-  tests/lanelet_test.cpp
-  tests/ego_test.cpp
-  tests/lane_segments_test.cpp
-  tests/pre_processing_utils_test.cpp
-  tests/fixed_queue_test.cpp
-  tests/postprocessing_utils_test.cpp
-  tests/utils_test.cpp
-  tests/marker_utils_test.cpp)
+    tests/agent_test.cpp
+    tests/lanelet_test.cpp
+    tests/ego_test.cpp
+    tests/lane_segments_test.cpp
+    tests/pre_processing_utils_test.cpp
+    tests/fixed_queue_test.cpp
+    tests/postprocessing_utils_test.cpp
+    tests/utils_test.cpp
+    tests/marker_utils_test.cpp)
 
-target_link_libraries(test_diffusion_planner autoware_diffusion_planner_component)
-
+  target_link_libraries(test_diffusion_planner autoware_diffusion_planner_component)
 endif()
 
 ament_auto_package(

--- a/config/diffusion_planner.param.yaml
+++ b/config/diffusion_planner.param.yaml
@@ -2,6 +2,8 @@
   ros__parameters:
     onnx_model_path: ""
     args_path: ""
+    backend: "TENSORRT" # Options: "TENSORRT", "ONNXRUNTIME"
+    plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
     planning_frequency_hz: 10.0
     predict_neighbor_trajectory: true
     update_traffic_light_group_info: true

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -22,6 +22,7 @@
 #include "autoware/diffusion_planner/utils/arg_reader.hpp"
 
 #include <Eigen/Dense>
+#include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware/tensorrt_common/tensorrt_common.hpp>
 #include <autoware/tensorrt_common/tensorrt_conv_calib.hpp>
@@ -93,6 +94,7 @@ using utils::NormalizationMap;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 // TensorRT
+using autoware::cuda_utils::CudaUniquePtr;
 using autoware::tensorrt_common::CalibrationConfig;
 using autoware::tensorrt_common::NetworkIOPtr;
 using autoware::tensorrt_common::ProfileDimsPtr;
@@ -186,6 +188,11 @@ public:
   void on_map(const HADMapBin::ConstSharedPtr map_msg);
 
   /**
+   * @brief Init TensorRT pointers.
+   */
+  void init_pointers();
+
+  /**
    * @brief Load ONNX model from file.
    * @param model_path Path to the ONNX model file.
    */
@@ -252,6 +259,17 @@ public:
   // TensorRT
   std::unique_ptr<TrtConvCalib> trt_common_;
   std::unique_ptr<autoware::tensorrt_common::TrtCommon> network_trt_ptr_{nullptr};
+  // For float inputs and output
+  CudaUniquePtr<float[]> ego_current_state_d_;
+  CudaUniquePtr<float[]> neighbor_agents_past_d_;
+  CudaUniquePtr<float[]> static_objects_d_;
+  CudaUniquePtr<float[]> lanes_d_;
+  CudaUniquePtr<float[]> lanes_speed_limit_d_;
+  CudaUniquePtr<float[]> route_lanes_d_;
+  CudaUniquePtr<float[]> output_d_;  // shape: [1, 11, 80, 4]
+
+  // For boolean input
+  CudaUniquePtr<bool[]> lanes_has_speed_limit_d_;
 
   // Model input data
   std::optional<AgentData> agent_data_{std::nullopt};

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -217,6 +217,12 @@ public:
   void publish_predictions(Ort::Value & predictions) const;
 
   /**
+   * @brief Publish model predictions.
+   * @param predictions Output from the model.
+   */
+  void publish_predictions(std::vector<float> & predictions) const;
+
+  /**
    * @brief Run inference on input data and return predictions.
    * @param input_data_map Input data for the model.
    * @return Optional vector of ONNX model outputs.

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -106,8 +106,8 @@ using autoware::tensorrt_common::TrtConvCalib;
 struct DiffusionPlannerParams
 {
   std::string model_path;
-  std::string engine_path;
   std::string args_path;
+  std::string backend;
   std::string plugins_path;
   double planning_frequency_hz;
   bool predict_neighbor_trajectory;
@@ -202,7 +202,7 @@ public:
    * @brief Load TensorRT engine from file.
    * @param model_path Path to the TensorRT engine file.
    */
-  void load_engine(const std::string & model_path, const std::string & engine_path);
+  void load_engine(const std::string & model_path);
 
   /**
    * @brief Publish visualization markers for debugging.
@@ -220,20 +220,20 @@ public:
    * @brief Publish model predictions.
    * @param predictions Output from the model.
    */
-  void publish_predictions(std::vector<float> & predictions) const;
+  void publish_predictions(const std::vector<float> & predictions) const;
 
   /**
    * @brief Run inference on input data and return predictions.
    * @param input_data_map Input data for the model.
    * @return Optional vector of ONNX model outputs.
    */
-  std::optional<std::vector<Ort::Value>> do_inference(InputDataMap & input_data_map);
+  std::vector<float> do_inference(InputDataMap & input_data_map);
 
   /**
    * @brief Run inference on input data output is stored on member output_d_.
    * @param input_data_map Input data for the model.
    */
-  void do_inference_trt(InputDataMap & input_data_map);
+  std::vector<float> do_inference_trt(InputDataMap & input_data_map);
 
   /**
    * @brief Callback for dynamic parameter updates.
@@ -253,10 +253,6 @@ public:
   std::pair<Eigen::Matrix4f, Eigen::Matrix4f> transforms_;
   AgentData get_ego_centric_agent_data(
     const TrackedObjects & objects, const Eigen::Matrix4f & map_to_ego_transform);
-
-  // postprocessing
-  Trajectory create_trajectory(
-    std::vector<Ort::Value> & predictions, Eigen::Matrix4f & transform_ego_to_map);
 
   // current state
   Odometry ego_kinematic_state_;

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -224,6 +224,12 @@ public:
   std::optional<std::vector<Ort::Value>> do_inference(InputDataMap & input_data_map);
 
   /**
+   * @brief Run inference on input data output is stored on member output_d_.
+   * @param input_data_map Input data for the model.
+   */
+  void do_inference_trt(InputDataMap & input_data_map);
+
+  /**
    * @brief Callback for dynamic parameter updates.
    * @param parameters Updated parameters.
    * @return Result of parameter update.

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -212,12 +212,6 @@ public:
 
   /**
    * @brief Publish model predictions.
-   * @param predictions Output from the ONNX model.
-   */
-  void publish_predictions(Ort::Value & predictions) const;
-
-  /**
-   * @brief Publish model predictions.
    * @param predictions Output from the model.
    */
   void publish_predictions(const std::vector<float> & predictions) const;

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -267,9 +267,8 @@ public:
   CudaUniquePtr<float[]> lanes_speed_limit_d_;
   CudaUniquePtr<float[]> route_lanes_d_;
   CudaUniquePtr<float[]> output_d_;  // shape: [1, 11, 80, 4]
-
-  // For boolean input
   CudaUniquePtr<bool[]> lanes_has_speed_limit_d_;
+  cudaStream_t stream_{nullptr};
 
   // Model input data
   std::optional<AgentData> agent_data_{std::nullopt};

--- a/include/autoware/diffusion_planner/dimensions.hpp
+++ b/include/autoware/diffusion_planner/dimensions.hpp
@@ -45,6 +45,7 @@ inline constexpr long SPEED_LIMIT = 12;
 inline constexpr long LANE_ID = 13;
 
 inline constexpr long OUTPUT_T = 80;  // Output timestamp number
+inline constexpr std::array<long, 4> OUTPUT_SHAPE = {1, 11, 80, 4};
 
 inline constexpr std::array<long, 2> EGO_CURRENT_STATE_SHAPE = {1, 10};
 inline constexpr std::array<long, 4> NEIGHBOR_SHAPE = {1, 32, 21, 11};

--- a/include/autoware/diffusion_planner/dimensions.hpp
+++ b/include/autoware/diffusion_planner/dimensions.hpp
@@ -45,7 +45,7 @@ inline constexpr long SPEED_LIMIT = 12;
 inline constexpr long LANE_ID = 13;
 
 inline constexpr long OUTPUT_T = 80;  // Output timestamp number
-inline constexpr std::array<long, 4> OUTPUT_SHAPE = {1, 11, 80, 4};
+inline constexpr std::array<long, 4> OUTPUT_SHAPE = {1, 33, 80, 4};
 
 inline constexpr std::array<long, 2> EGO_CURRENT_STATE_SHAPE = {1, 10};
 inline constexpr std::array<long, 4> NEIGHBOR_SHAPE = {1, 32, 21, 11};

--- a/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -56,15 +56,6 @@ void transform_output_matrix(
   long row_idx, bool do_translation = true);
 
 /**
- * @brief Extracts tensor data from an ONNX prediction into an Eigen matrix.
- *
- * @param prediction The ONNX prediction output.
- * @return An Eigen matrix containing the tensor data in row-major order.
- */
-Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
-  Ort::Value & prediction);
-
-/**
  * @brief Extracts tensor data from tensor prediction into an Eigen matrix.
  *
  * @param prediction The tensor prediction output.
@@ -72,19 +63,6 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
  */
 Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
   const std::vector<float> & prediction);
-
-/**
- * @brief Converts ONNX prediction output to a prediction matrix in map coordinates.
- *
- * @param prediction The ONNX prediction output.
- * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
- * @param batch The batch index to extract.
- * @param agent The agent index to extract.
- * @return The prediction matrix for the specified batch and agent.
- */
-Eigen::MatrixXf get_prediction_matrix(
-  Ort::Value & prediction, const Eigen::Matrix4f & transform_ego_to_map, const long batch = 0,
-  const long agent = 0);
 
 /**
  * @brief Converts tensor prediction output to a prediction matrix in map coordinates.
@@ -98,19 +76,6 @@ Eigen::MatrixXf get_prediction_matrix(
 Eigen::MatrixXf get_prediction_matrix(
   const std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map,
   const long batch = 0, const long agent = 0);
-
-/**
- * @brief Creates PredictedObjects message from ONNX prediction and agent data.
- *
- * @param prediction The ONNX prediction output.
- * @param ego_centric_agent_data The agent data in ego-centric coordinates.
- * @param stamp The ROS time stamp for the message.
- * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
- * @return A PredictedObjects message containing predicted paths for each agent.
- */
-PredictedObjects create_predicted_objects(
-  Ort::Value & prediction, const AgentData & ego_centric_agent_data, const rclcpp::Time & stamp,
-  const Eigen::Matrix4f & transform_ego_to_map);
 
 /**
  * @brief Creates PredictedObjects message from tensor prediction and agent data.
@@ -137,20 +102,6 @@ Trajectory get_trajectory_from_prediction_matrix(
   const rclcpp::Time & stamp);
 
 /**
- * @brief Creates a Trajectory message from ONNX prediction for a specific batch and agent.
- *
- * @param prediction The ONNX prediction output.
- * @param stamp The ROS time stamp for the message.
- * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
- * @param batch The batch index to extract.
- * @param agent The agent index to extract.
- * @return A Trajectory message for the specified batch and agent.
- */
-Trajectory create_trajectory(
-  Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
-  long batch, long agent);
-
-/**
  * @brief Creates a Trajectory message from tensor prediction for a specific batch and agent.
  *
  * @param prediction The tensor prediction output.
@@ -163,21 +114,6 @@ Trajectory create_trajectory(
 Trajectory create_trajectory(
   const std::vector<float> & prediction, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map, long batch, long agent);
-
-/**
- * @brief Creates multiple Trajectory messages from ONNX prediction for a range of batches and
- * agents.
- *
- * @param prediction The ONNX prediction output.
- * @param stamp The ROS time stamp for the messages.
- * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
- * @param start_batch The starting batch index.
- * @param start_agent The starting agent index.
- * @return A vector of Trajectory messages.
- */
-std::vector<Trajectory> create_multiple_trajectories(
-  Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
-  long start_batch, long start_agent);
 
 /**
  * @brief Creates multiple Trajectory messages from tensor prediction for a range of batches and

--- a/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -65,6 +65,15 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
   Ort::Value & prediction);
 
 /**
+ * @brief Extracts tensor data from tensor prediction into an Eigen matrix.
+ *
+ * @param prediction The tensor prediction output.
+ * @return An Eigen matrix containing the tensor data in row-major order.
+ */
+Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
+  std::vector<float> & prediction);
+
+/**
  * @brief Converts ONNX prediction output to a prediction matrix in map coordinates.
  *
  * @param prediction The ONNX prediction output.
@@ -76,6 +85,19 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
 Eigen::MatrixXf get_prediction_matrix(
   Ort::Value & prediction, const Eigen::Matrix4f & transform_ego_to_map, const long batch = 0,
   const long agent = 0);
+
+/**
+ * @brief Converts tensor prediction output to a prediction matrix in map coordinates.
+ *
+ * @param prediction The tensor prediction output.
+ * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
+ * @param batch The batch index to extract.
+ * @param agent The agent index to extract.
+ * @return The prediction matrix for the specified batch and agent.
+ */
+Eigen::MatrixXf get_prediction_matrix(
+  std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map,
+  const long batch = 0, const long agent = 0);
 
 /**
  * @brief Creates PredictedObjects message from ONNX prediction and agent data.
@@ -90,6 +112,18 @@ PredictedObjects create_predicted_objects(
   Ort::Value & prediction, const AgentData & ego_centric_agent_data, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map);
 
+/**
+ * @brief Creates PredictedObjects message from tensor prediction and agent data.
+ *
+ * @param prediction The tensor prediction output.
+ * @param ego_centric_agent_data The agent data in ego-centric coordinates.
+ * @param stamp The ROS time stamp for the message.
+ * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
+ * @return A PredictedObjects message containing predicted paths for each agent.
+ */
+PredictedObjects create_predicted_objects(
+  std::vector<float> prediction, const AgentData & ego_centric_agent_data,
+  const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map);
 /**
  * @brief Converts a prediction matrix to a Trajectory message.
  *
@@ -117,6 +151,20 @@ Trajectory create_trajectory(
   long batch, long agent);
 
 /**
+ * @brief Creates a Trajectory message from tensor prediction for a specific batch and agent.
+ *
+ * @param prediction The tensor prediction output.
+ * @param stamp The ROS time stamp for the message.
+ * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
+ * @param batch The batch index to extract.
+ * @param agent The agent index to extract.
+ * @return A Trajectory message for the specified batch and agent.
+ */
+Trajectory create_trajectory(
+  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const Eigen::Matrix4f & transform_ego_to_map, long batch, long agent);
+
+/**
  * @brief Creates multiple Trajectory messages from ONNX prediction for a range of batches and
  * agents.
  *
@@ -130,6 +178,21 @@ Trajectory create_trajectory(
 std::vector<Trajectory> create_multiple_trajectories(
   Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
   long start_batch, long start_agent);
+
+/**
+ * @brief Creates multiple Trajectory messages from tensor prediction for a range of batches and
+ * agents.
+ *
+ * @param prediction The tensor prediction output.
+ * @param stamp The ROS time stamp for the messages.
+ * @param transform_ego_to_map The transformation matrix from ego to map coordinates.
+ * @param start_batch The starting batch index.
+ * @param start_agent The starting agent index.
+ * @return A vector of Trajectory messages.
+ */
+std::vector<Trajectory> create_multiple_trajectories(
+  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const Eigen::Matrix4f & transform_ego_to_map, long start_batch, long start_agent);
 
 /**
  * @brief Converts a Trajectory message to a Trajectories message with generator info.

--- a/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/diffusion_planner/conversion/agent.hpp"
 #include "onnxruntime_cxx_api.h"
-#include "rclcpp/rclcpp.hpp"
 
 #include <Eigen/Dense>
+#include <rclcpp/rclcpp.hpp>
 
 #include <autoware_new_planning_msgs/msg/trajectories.hpp>
 #include <autoware_perception_msgs/msg/detail/object_classification__struct.hpp>
@@ -71,7 +71,7 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
  * @return An Eigen matrix containing the tensor data in row-major order.
  */
 Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
-  std::vector<float> & prediction);
+  const std::vector<float> & prediction);
 
 /**
  * @brief Converts ONNX prediction output to a prediction matrix in map coordinates.
@@ -96,7 +96,7 @@ Eigen::MatrixXf get_prediction_matrix(
  * @return The prediction matrix for the specified batch and agent.
  */
 Eigen::MatrixXf get_prediction_matrix(
-  std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map,
+  const std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map,
   const long batch = 0, const long agent = 0);
 
 /**
@@ -122,7 +122,7 @@ PredictedObjects create_predicted_objects(
  * @return A PredictedObjects message containing predicted paths for each agent.
  */
 PredictedObjects create_predicted_objects(
-  std::vector<float> prediction, const AgentData & ego_centric_agent_data,
+  const std::vector<float> & prediction, const AgentData & ego_centric_agent_data,
   const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map);
 /**
  * @brief Converts a prediction matrix to a Trajectory message.
@@ -161,7 +161,7 @@ Trajectory create_trajectory(
  * @return A Trajectory message for the specified batch and agent.
  */
 Trajectory create_trajectory(
-  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const std::vector<float> & prediction, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map, long batch, long agent);
 
 /**
@@ -191,7 +191,7 @@ std::vector<Trajectory> create_multiple_trajectories(
  * @return A vector of Trajectory messages.
  */
 std::vector<Trajectory> create_multiple_trajectories(
-  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const std::vector<float> & prediction, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map, long start_batch, long start_agent);
 
 /**

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,8 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_tensorrt_common</depend>
-
+  <depend>autoware_cuda_dependency_meta</depend>
+  <depend>autoware_cuda_utils</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_vehicle_info_utils</depend>

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,8 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
+  <depend>autoware_tensorrt_common</depend>
+
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_vehicle_info_utils</depend>
@@ -32,6 +34,8 @@
   <depend>lanelet2_core</depend>
   <depend>lanelet2_routing</depend>
   <depend>lanelet2_traffic_rules</depend>
+
+  <exec_depend>autoware_tensorrt_plugins</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/src/diffusion_planner_node.cpp
+++ b/src/diffusion_planner_node.cpp
@@ -36,6 +36,7 @@
 #include <limits>
 #include <numeric>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace autoware::diffusion_planner
@@ -65,6 +66,7 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
 
   normalization_map_ = utils::load_normalization_stats(params_.args_path);
   load_model(params_.model_path);
+  load_engine(params_.model_path, params_.engine_path);
 
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
 
@@ -143,6 +145,52 @@ void DiffusionPlanner::load_model(const std::string & model_path)
   session_options_.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_BASIC);
   session_ = Ort::Session(env_, model_path.c_str(), session_options_);
   RCLCPP_INFO(get_logger(), "Model loaded from %s", params_.model_path.c_str());
+}
+
+void DiffusionPlanner::load_engine(
+  const std::string & model_path, [[maybe_unused]] const std::string & engine_path)
+{
+  std::string precision = "fp32";  // Default precision
+  auto trt_config = tensorrt_common::TrtCommonConfig(model_path, precision);
+  trt_common_ = std::make_unique<TrtConvCalib>(trt_config);
+
+  // const auto network_input_dims = trt_common_->getTensorShape(0);
+
+  auto profile_dims_ptr = std::make_unique<std::vector<autoware::tensorrt_common::ProfileDims>>();
+  std::vector<autoware::tensorrt_common::NetworkIO> network_io;
+
+  // Inputs
+  network_io.emplace_back("ego_current_state", nvinfer1::Dims{2, {1, 10}});
+  network_io.emplace_back("neighbor_agents_past", nvinfer1::Dims{4, {1, 32, 21, 11}});
+  network_io.emplace_back("static_objects", nvinfer1::Dims{3, {1, 5, 10}});
+  network_io.emplace_back("lanes", nvinfer1::Dims{4, {1, 70, 20, 12}});
+  network_io.emplace_back("lanes_speed_limit", nvinfer1::Dims{3, {1, 70, 1}});
+  network_io.emplace_back("lanes_has_speed_limit", nvinfer1::Dims{3, {1, 70, 1}});
+  network_io.emplace_back("route_lanes", nvinfer1::Dims{4, {1, 25, 20, 12}});
+
+  // Output
+  network_io.emplace_back("output", nvinfer1::Dims{4, {1, 11, 80, 4}});
+
+  auto network_io_ptr =
+    std::make_unique<std::vector<autoware::tensorrt_common::NetworkIO>>(network_io);
+
+  network_trt_ptr_ = std::make_unique<autoware::tensorrt_common::TrtCommon>(
+    trt_config, std::make_shared<autoware::tensorrt_common::Profiler>(),
+    std::vector<std::string>{params_.plugins_path});
+
+  if (!network_trt_ptr_->setup(std::move(profile_dims_ptr), std::move(network_io_ptr))) {
+    throw std::runtime_error("Failed to setup TRT engine." + params_.plugins_path);
+  }
+  // Create runtime
+  // IRuntime * runtime = createInferRuntime(gLogger);
+  // if (!runtime) throw std::runtime_error("Failed to create TRT runtime");
+
+  // // Load engine data from file
+  // std::vector<char> engineData = loadEngineFile(engineFile);
+
+  // // Deserialize engine
+  // ICudaEngine * engine = runtime->deserializeCudaEngine(engineData.data(), engineData.size());
+  // if (!engine) throw std::runtime_error("Failed to deserialize engine");
 }
 
 AgentData DiffusionPlanner::get_ego_centric_agent_data(

--- a/src/diffusion_planner_node.cpp
+++ b/src/diffusion_planner_node.cpp
@@ -415,28 +415,6 @@ void DiffusionPlanner::publish_predictions(const std::vector<float> & prediction
   }
 }
 
-void DiffusionPlanner::publish_predictions(Ort::Value & predictions) const
-{
-  constexpr long batch_idx = 0;
-  constexpr long ego_agent_idx = 0;
-  auto output_trajectory = postprocessing::create_trajectory(
-    predictions, this->now(), transforms_.first, batch_idx, ego_agent_idx);
-  pub_trajectory_->publish(output_trajectory);
-
-  auto ego_trajectory_as_new_msg =
-    postprocessing::to_trajectories_msg(output_trajectory, generator_uuid_, "DiffusionPlanner");
-  pub_trajectories_->publish(ego_trajectory_as_new_msg);
-
-  // Other agents prediction
-  if (params_.predict_neighbor_trajectory && agent_data_.has_value()) {
-    auto reduced_agent_data = agent_data_.value();
-    reduced_agent_data.trim_to_k_closest_agents(ego_kinematic_state_.pose.pose.position);
-    auto predicted_objects = postprocessing::create_predicted_objects(
-      predictions, reduced_agent_data, this->now(), transforms_.first);
-    pub_objects_->publish(predicted_objects);
-  }
-}
-
 std::vector<float> DiffusionPlanner::do_inference_trt(InputDataMap & input_data_map)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);

--- a/src/diffusion_planner_node.cpp
+++ b/src/diffusion_planner_node.cpp
@@ -211,6 +211,31 @@ void DiffusionPlanner::load_engine(
   if (!network_trt_ptr_->setup(std::move(profile_dims_ptr), std::move(network_io_ptr))) {
     throw std::runtime_error("Failed to setup TRT engine." + params_.plugins_path);
   }
+
+  // Set tensor addresses and input shapes
+  bool set_input_shapes = true;
+  set_input_shapes &=
+    network_trt_ptr_->setInputShape("ego_current_state", toDims(EGO_CURRENT_STATE_SHAPE));
+  set_input_shapes &=
+    network_trt_ptr_->setInputShape("neighbor_agents_past", toDims(NEIGHBOR_SHAPE));
+  set_input_shapes &=
+    network_trt_ptr_->setInputShape("static_objects", toDims(STATIC_OBJECTS_SHAPE));
+  set_input_shapes &= network_trt_ptr_->setInputShape("lanes", toDims(LANES_SHAPE));
+  set_input_shapes &=
+    network_trt_ptr_->setInputShape("lanes_speed_limit", toDims(LANES_SPEED_LIMIT_SHAPE));
+  set_input_shapes &=
+    network_trt_ptr_->setInputShape("lanes_has_speed_limit", toDims(LANE_HAS_SPEED_LIMIT_SHAPE));
+  set_input_shapes &= network_trt_ptr_->setInputShape("route_lanes", toDims(ROUTE_LANES_SHAPE));
+  if (!set_input_shapes) {
+    throw std::runtime_error("Failed to set input shapes for TensorRT engine.");
+  }
+  // network_trt_ptr_->setTensorAddress("ego_current_state", ego_current_state_d_.get());
+  // network_trt_ptr_->setTensorAddress("neighbor_agents_past", neighbor_agents_past_d_.get());
+  // network_trt_ptr_->setTensorAddress("static_objects", static_objects_d_.get());
+  // network_trt_ptr_->setTensorAddress("lanes", lanes_d_.get());
+  // network_trt_ptr_->setTensorAddress("lanes_speed_limit", lanes_speed_limit_d_.get());
+  // network_trt_ptr_->setTensorAddress("lanes_has_speed_limit", lanes_has_speed_limit_d_.get());
+  // network_trt_ptr_->setTensorAddress("route_lanes", route_lanes_d_.get());
 }
 
 AgentData DiffusionPlanner::get_ego_centric_agent_data(

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <vector>
 
 namespace autoware::diffusion_planner::postprocessing
 {
@@ -54,6 +55,71 @@ void transform_output_matrix(
 };
 
 PredictedObjects create_predicted_objects(
+  std::vector<float> prediction, const AgentData & ego_centric_agent_data,
+  const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map)
+{
+  auto trajectory_path_to_pose_path =
+    [&](const Trajectory & trajectory) -> std::vector<geometry_msgs::msg::Pose> {
+    std::vector<geometry_msgs::msg::Pose> pose_path;
+    std::for_each(trajectory.points.begin(), trajectory.points.end(), [&](const auto & p) {
+      pose_path.push_back(p.pose);
+    });
+
+    return pose_path;
+  };
+
+  const auto objects_history = ego_centric_agent_data.get_histories();
+
+  PredictedObjects predicted_objects;
+  predicted_objects.header.stamp = stamp;
+  predicted_objects.header.frame_id = "map";
+
+  constexpr double time_step{0.1};
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+  constexpr auto agent_size = prediction_shape[1];
+
+  // get agent trajectories excluding ego (start from batch 0, and agent 1)
+  constexpr long start_batch = 0;
+  constexpr long start_agent = 1;
+
+  auto agent_trajectories =
+    create_multiple_trajectories(prediction, stamp, transform_ego_to_map, start_batch, start_agent);
+
+  // First prediction is of ego (agent 0). Predictions from index 1 to last are of the closest
+  // neighbors. ego_centric_agent_data contains neighbor history information ordered by distance.
+  for (long agent = 1; agent < agent_size; ++agent) {
+    if (static_cast<size_t>(agent) > objects_history.size()) {
+      break;
+    }
+    PredictedObject object;
+    const auto & object_info = objects_history.at(agent - 1).get_latest_state().tracked_object();
+    {  // Extract path from prediction
+      const auto & trajectory_points_in_map_reference = agent_trajectories.at(agent - 1);
+      PredictedPath predicted_path;
+      predicted_path.path = trajectory_path_to_pose_path(trajectory_points_in_map_reference);
+      predicted_path.time_step = rclcpp::Duration::from_seconds(time_step);
+      predicted_path.confidence = 1.0;
+      object.kinematics.predicted_paths.push_back(predicted_path);
+    }
+    {  // Copy kinematics
+      object.kinematics.initial_twist_with_covariance =
+        object_info.kinematics.twist_with_covariance;
+      object.kinematics.initial_acceleration_with_covariance =
+        object_info.kinematics.acceleration_with_covariance;
+      object.kinematics.initial_pose_with_covariance = object_info.kinematics.pose_with_covariance;
+    }
+    {  // Copy the remaining info
+      object.object_id = object_info.object_id;
+      object.classification = object_info.classification;
+      object.shape = object_info.shape;
+      object.existence_probability = object_info.existence_probability;
+    }
+    predicted_objects.objects.push_back(object);
+  }
+  return predicted_objects;
+}
+
+PredictedObjects create_predicted_objects(
   Ort::Value & prediction, const AgentData & ego_centric_agent_data, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map)
 {
@@ -74,8 +140,8 @@ PredictedObjects create_predicted_objects(
   predicted_objects.header.frame_id = "map";
 
   constexpr double time_step{0.1};
-  const auto prediction_shape = prediction.GetTensorTypeAndShapeInfo().GetShape();
-  auto agent_size = prediction_shape[1];
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+  constexpr auto agent_size = prediction_shape[1];
 
   // get agent trajectories excluding ego (start from batch 0, and agent 1)
   constexpr long start_batch = 0;
@@ -119,9 +185,26 @@ PredictedObjects create_predicted_objects(
 }
 
 Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
+  std::vector<float> & prediction)
+{
+  // copy relevant part of data to Eigen matrix
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+
+  auto batch_size = prediction_shape[0];
+  auto agent_size = prediction_shape[1];
+  auto rows = prediction_shape[2];
+  auto cols = prediction_shape[3];
+
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data(
+    batch_size * agent_size * rows, cols);
+  std::memcpy(tensor_data.data(), prediction.data(), tensor_data.size() * sizeof(float));
+  return tensor_data;
+}
+
+Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
   Ort::Value & prediction)
 {
-  const auto prediction_shape = prediction.GetTensorTypeAndShapeInfo().GetShape();
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
 
   // copy relevant part of data to Eigen matrix
   auto batch_size = prediction_shape[0];
@@ -138,11 +221,35 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
 }
 
 Eigen::MatrixXf get_prediction_matrix(
+  std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map, const long batch,
+  const long agent)
+{
+  // TODO(Daniel): add batch support
+  const auto prediction_shape = OUTPUT_SHAPE;
+
+  // copy relevant part of data to Eigen matrix
+  auto agent_size = prediction_shape[1];
+  auto rows = prediction_shape[2];
+  auto cols = prediction_shape[3];
+
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data =
+    get_tensor_data(prediction);
+  Eigen::MatrixXf prediction_matrix =
+    tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
+
+  // Copy only the relevant part
+  prediction_matrix.transposeInPlace();
+  postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 0, true);
+  postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 2, false);
+  return prediction_matrix.transpose();
+}
+
+Eigen::MatrixXf get_prediction_matrix(
   Ort::Value & prediction, const Eigen::Matrix4f & transform_ego_to_map, const long batch,
   const long agent)
 {
   // TODO(Daniel): add batch support
-  const auto prediction_shape = prediction.GetTensorTypeAndShapeInfo().GetShape();
+  const auto prediction_shape = OUTPUT_SHAPE;
 
   // copy relevant part of data to Eigen matrix
   auto agent_size = prediction_shape[1];
@@ -192,6 +299,16 @@ Trajectory get_trajectory_from_prediction_matrix(
 }
 
 Trajectory create_trajectory(
+  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const Eigen::Matrix4f & transform_ego_to_map, long batch, long agent)
+{
+  // one batch of prediction
+  Eigen::MatrixXf prediction_matrix =
+    get_prediction_matrix(prediction, transform_ego_to_map, batch, agent);
+  return get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp);
+}
+
+Trajectory create_trajectory(
   Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
   long batch, long agent)
 {
@@ -202,14 +319,45 @@ Trajectory create_trajectory(
 }
 
 std::vector<Trajectory> create_multiple_trajectories(
+  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const Eigen::Matrix4f & transform_ego_to_map, long start_batch, long start_agent)
+{
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+  constexpr auto batch_size = prediction_shape[0];
+  constexpr auto agent_size = prediction_shape[1];
+  constexpr auto rows = prediction_shape[2];
+  constexpr auto cols = prediction_shape[3];
+
+  std::vector<Trajectory> agent_trajectories;
+  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data =
+    get_tensor_data(prediction);
+
+  for (long batch = start_batch; batch < batch_size; ++batch) {
+    for (long agent = start_agent; agent < agent_size; ++agent) {
+      // Copy only the relevant part
+      Eigen::MatrixXf prediction_matrix =
+        tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
+
+      prediction_matrix.transposeInPlace();
+      postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 0, true);
+      postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 2, false);
+      prediction_matrix.transposeInPlace();
+      agent_trajectories.push_back(
+        get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp));
+    }
+  }
+  return agent_trajectories;
+}
+
+std::vector<Trajectory> create_multiple_trajectories(
   Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
   long start_batch, long start_agent)
 {
-  const auto prediction_shape = prediction.GetTensorTypeAndShapeInfo().GetShape();
-  auto batch_size = prediction_shape[0];
-  auto agent_size = prediction_shape[1];
-  auto rows = prediction_shape[2];
-  auto cols = prediction_shape[3];
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+  constexpr auto batch_size = prediction_shape[0];
+  constexpr auto agent_size = prediction_shape[1];
+  constexpr auto rows = prediction_shape[2];
+  constexpr auto cols = prediction_shape[3];
 
   std::vector<Trajectory> agent_trajectories;
   Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data =

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -119,71 +119,6 @@ PredictedObjects create_predicted_objects(
   return predicted_objects;
 }
 
-PredictedObjects create_predicted_objects(
-  Ort::Value & prediction, const AgentData & ego_centric_agent_data, const rclcpp::Time & stamp,
-  const Eigen::Matrix4f & transform_ego_to_map)
-{
-  auto trajectory_path_to_pose_path =
-    [&](const Trajectory & trajectory) -> std::vector<geometry_msgs::msg::Pose> {
-    std::vector<geometry_msgs::msg::Pose> pose_path;
-    std::for_each(trajectory.points.begin(), trajectory.points.end(), [&](const auto & p) {
-      pose_path.push_back(p.pose);
-    });
-
-    return pose_path;
-  };
-
-  const auto objects_history = ego_centric_agent_data.get_histories();
-
-  PredictedObjects predicted_objects;
-  predicted_objects.header.stamp = stamp;
-  predicted_objects.header.frame_id = "map";
-
-  constexpr double time_step{0.1};
-  constexpr auto prediction_shape = OUTPUT_SHAPE;
-  constexpr auto agent_size = prediction_shape[1];
-
-  // get agent trajectories excluding ego (start from batch 0, and agent 1)
-  constexpr long start_batch = 0;
-  constexpr long start_agent = 1;
-
-  auto agent_trajectories =
-    create_multiple_trajectories(prediction, stamp, transform_ego_to_map, start_batch, start_agent);
-
-  // First prediction is of ego (agent 0). Predictions from index 1 to last are of the closest
-  // neighbors. ego_centric_agent_data contains neighbor history information ordered by distance.
-  for (long agent = 1; agent < agent_size; ++agent) {
-    if (static_cast<size_t>(agent) > objects_history.size()) {
-      break;
-    }
-    PredictedObject object;
-    const auto & object_info = objects_history.at(agent - 1).get_latest_state().tracked_object();
-    {  // Extract path from prediction
-      const auto & trajectory_points_in_map_reference = agent_trajectories.at(agent - 1);
-      PredictedPath predicted_path;
-      predicted_path.path = trajectory_path_to_pose_path(trajectory_points_in_map_reference);
-      predicted_path.time_step = rclcpp::Duration::from_seconds(time_step);
-      predicted_path.confidence = 1.0;
-      object.kinematics.predicted_paths.push_back(predicted_path);
-    }
-    {  // Copy kinematics
-      object.kinematics.initial_twist_with_covariance =
-        object_info.kinematics.twist_with_covariance;
-      object.kinematics.initial_acceleration_with_covariance =
-        object_info.kinematics.acceleration_with_covariance;
-      object.kinematics.initial_pose_with_covariance = object_info.kinematics.pose_with_covariance;
-    }
-    {  // Copy the remaining info
-      object.object_id = object_info.object_id;
-      object.classification = object_info.classification;
-      object.shape = object_info.shape;
-      object.existence_probability = object_info.existence_probability;
-    }
-    predicted_objects.objects.push_back(object);
-  }
-  return predicted_objects;
-}
-
 Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
   const std::vector<float> & prediction)
 {
@@ -201,52 +136,9 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
   return tensor_data;
 }
 
-Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
-  Ort::Value & prediction)
-{
-  constexpr auto prediction_shape = OUTPUT_SHAPE;
-
-  // copy relevant part of data to Eigen matrix
-  auto batch_size = prediction_shape[0];
-  auto agent_size = prediction_shape[1];
-  auto rows = prediction_shape[2];
-  auto cols = prediction_shape[3];
-
-  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data(
-    batch_size * agent_size * rows, cols);
-  std::memcpy(
-    tensor_data.data(), prediction.GetTensorMutableData<float>(),
-    tensor_data.size() * sizeof(float));
-  return tensor_data;
-}
-
 Eigen::MatrixXf get_prediction_matrix(
   const std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map,
   const long batch, const long agent)
-{
-  // TODO(Daniel): add batch support
-  const auto prediction_shape = OUTPUT_SHAPE;
-
-  // copy relevant part of data to Eigen matrix
-  auto agent_size = prediction_shape[1];
-  auto rows = prediction_shape[2];
-  auto cols = prediction_shape[3];
-
-  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data =
-    get_tensor_data(prediction);
-  Eigen::MatrixXf prediction_matrix =
-    tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
-
-  // Copy only the relevant part
-  prediction_matrix.transposeInPlace();
-  postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 0, true);
-  postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 2, false);
-  return prediction_matrix.transpose();
-}
-
-Eigen::MatrixXf get_prediction_matrix(
-  Ort::Value & prediction, const Eigen::Matrix4f & transform_ego_to_map, const long batch,
-  const long agent)
 {
   // TODO(Daniel): add batch support
   const auto prediction_shape = OUTPUT_SHAPE;
@@ -308,50 +200,9 @@ Trajectory create_trajectory(
   return get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp);
 }
 
-Trajectory create_trajectory(
-  Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
-  long batch, long agent)
-{
-  // one batch of prediction
-  Eigen::MatrixXf prediction_matrix =
-    get_prediction_matrix(prediction, transform_ego_to_map, batch, agent);
-  return get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp);
-}
-
 std::vector<Trajectory> create_multiple_trajectories(
   const std::vector<float> & prediction, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map, long start_batch, long start_agent)
-{
-  constexpr auto prediction_shape = OUTPUT_SHAPE;
-  constexpr auto batch_size = prediction_shape[0];
-  constexpr auto agent_size = prediction_shape[1];
-  constexpr auto rows = prediction_shape[2];
-  constexpr auto cols = prediction_shape[3];
-
-  std::vector<Trajectory> agent_trajectories;
-  Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data =
-    get_tensor_data(prediction);
-
-  for (long batch = start_batch; batch < batch_size; ++batch) {
-    for (long agent = start_agent; agent < agent_size; ++agent) {
-      // Copy only the relevant part
-      Eigen::MatrixXf prediction_matrix =
-        tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
-
-      prediction_matrix.transposeInPlace();
-      postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 0, true);
-      postprocessing::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 2, false);
-      prediction_matrix.transposeInPlace();
-      agent_trajectories.push_back(
-        get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp));
-    }
-  }
-  return agent_trajectories;
-}
-
-std::vector<Trajectory> create_multiple_trajectories(
-  Ort::Value & prediction, const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map,
-  long start_batch, long start_agent)
 {
   constexpr auto prediction_shape = OUTPUT_SHAPE;
   constexpr auto batch_size = prediction_shape[0];

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -55,7 +55,7 @@ void transform_output_matrix(
 };
 
 PredictedObjects create_predicted_objects(
-  std::vector<float> prediction, const AgentData & ego_centric_agent_data,
+  const std::vector<float> & prediction, const AgentData & ego_centric_agent_data,
   const rclcpp::Time & stamp, const Eigen::Matrix4f & transform_ego_to_map)
 {
   auto trajectory_path_to_pose_path =
@@ -185,7 +185,7 @@ PredictedObjects create_predicted_objects(
 }
 
 Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor_data(
-  std::vector<float> & prediction)
+  const std::vector<float> & prediction)
 {
   // copy relevant part of data to Eigen matrix
   constexpr auto prediction_shape = OUTPUT_SHAPE;
@@ -221,8 +221,8 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
 }
 
 Eigen::MatrixXf get_prediction_matrix(
-  std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map, const long batch,
-  const long agent)
+  const std::vector<float> & prediction, const Eigen::Matrix4f & transform_ego_to_map,
+  const long batch, const long agent)
 {
   // TODO(Daniel): add batch support
   const auto prediction_shape = OUTPUT_SHAPE;
@@ -299,7 +299,7 @@ Trajectory get_trajectory_from_prediction_matrix(
 }
 
 Trajectory create_trajectory(
-  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const std::vector<float> & prediction, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map, long batch, long agent)
 {
   // one batch of prediction
@@ -319,7 +319,7 @@ Trajectory create_trajectory(
 }
 
 std::vector<Trajectory> create_multiple_trajectories(
-  std::vector<float> & prediction, const rclcpp::Time & stamp,
+  const std::vector<float> & prediction, const rclcpp::Time & stamp,
   const Eigen::Matrix4f & transform_ego_to_map, long start_batch, long start_agent)
 {
   constexpr auto prediction_shape = OUTPUT_SHAPE;


### PR DESCRIPTION
This PR adds TensorRT support. It adds the option to choose between TensorRT and onnxruntime as backends for the diffusion planner. 

TensorRT as backend cuts the inference time by more than half: 

ONNXRUNTIME:
nodes:
- id: 1
  name: on_timer
  processing_time: 18.519
  parent_id: 0
  comment: ''
- id: 2
  name: create_input_data
  processing_time: 0.127
  parent_id: 1
  comment: ''
- id: 3
  name: do_inference
  processing_time: 18.188
  parent_id: 1
  comment: ''
---

TENSORRT

---
nodes:
- id: 1
  name: on_timer
  processing_time: 5.836
  parent_id: 0
  comment: ''
- id: 2
  name: create_input_data
  processing_time: 0.125
  parent_id: 1
  comment: ''
- id: 3
  name: do_inference_trt
  processing_time: 5.514
  parent_id: 1
  comment: ''
---

