### PR TITLE
feat: add build only option

### DIFF
--- a/config/diffusion_planner.param.yaml
+++ b/config/diffusion_planner.param.yaml
@@ -4,6 +4,7 @@
     args_path: ""
     backend: "TENSORRT" # Options: "TENSORRT", "ONNXRUNTIME"
     plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
+    build_only: false
     planning_frequency_hz: 10.0
     predict_neighbor_trajectory: true
     update_traffic_light_group_info: true

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -109,6 +109,7 @@ struct DiffusionPlannerParams
   std::string args_path;
   std::string backend;
   std::string plugins_path;
+  bool build_only;
   double planning_frequency_hz;
   bool predict_neighbor_trajectory;
   bool update_traffic_light_group_info;

--- a/launch/build_only.launch.xml
+++ b/launch/build_only.launch.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
+  <!-- <arg name="onnx_model_path" default="$(env HOME)/pilot-auto-new-framework/src/autoware/trajectory_generator/autoware_diffusion_planner/data/model.onnx"/> -->
+  <arg name="onnx_model_path" default="$(env HOME)/Desktop/diffusion_planner_chkpt_250521/latest_25-05-21.onnx"/>
+  <arg name="args_path" default="$(env HOME)/pilot-auto-new-framework/src/autoware/trajectory_generator/autoware_diffusion_planner/data/args.json"/>
+  <arg name="input/vector_map" default="/map/vector_map"/>
+
+  <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="screen">
+    <param from="$(var diffusion_planner_param_path)" allow_substs="true"/>
+    <remap from="~/output/trajectory" to="/planning/scenario_planning/lane_driving/unused/trajectory"/>
+    <remap from="~/output/trajectories" to="/diffusion_planner/trajectories"/>
+    <remap from="~/output/predicted_objects" to="~/diffusion_planner/predicted_objects"/>
+    <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+    <remap from="~/input/acceleration" to="/localization/acceleration"/>
+    <remap from="~/input/route" to="/planning/mission_planning/route"/>
+    <remap from="~/input/traffic_signals" to="/perception/traffic_light_recognition/traffic_signals"/>
+    <remap from="~/input/tracked_objects" to="/perception/object_recognition/tracking/objects"/>
+    <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
+    <param name="onnx_model_path" value="$(var onnx_model_path)"/>
+    <param name="args_path" value="$(var args_path)"/>
+    <param name="build_only" value="true"/>
+  </node>
+</launch>

--- a/src/diffusion_planner_node.cpp
+++ b/src/diffusion_planner_node.cpp
@@ -71,6 +71,11 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     std::exit(EXIT_FAILURE);
   }
 
+  if (params_.build_only) {
+    RCLCPP_INFO(get_logger(), "Build only mode enabled. Exiting after loading model.");
+    std::exit(EXIT_SUCCESS);
+  }
+
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
 
   timer_ = rclcpp::create_timer(
@@ -93,6 +98,7 @@ void DiffusionPlanner::set_up_params()
   params_.args_path = this->declare_parameter<std::string>("args_path", "");
   params_.backend = this->declare_parameter<std::string>("backend", "TENSORRT");
   params_.plugins_path = this->declare_parameter<std::string>("plugins_path", "");
+  params_.build_only = this->declare_parameter<bool>("build_only", false);
   params_.planning_frequency_hz = this->declare_parameter<double>("planning_frequency_hz", 10.0);
   params_.predict_neighbor_trajectory =
     this->declare_parameter<bool>("predict_neighbor_trajectory", false);


### PR DESCRIPTION
This small PR adds a build only option that lets the diffusion planner build the tensorRT engine and then exit. 