### PR TITLE
fix: `backward_path_length` and `forward_path_length` to match the training setting

### DIFF
--- a/src/diffusion_planner_node.cpp
+++ b/src/diffusion_planner_node.cpp
@@ -406,17 +406,18 @@ void DiffusionPlanner::publish_debug_markers(InputDataMap & input_data_map) cons
   if (debug_params_.publish_debug_route) {
     auto lifetime = rclcpp::Duration::from_seconds(0.2);
     auto route_markers = utils::create_lane_marker(
-      input_data_map["route_lanes"],
+      transforms_.first, input_data_map["route_lanes"],
       std::vector<long>(ROUTE_LANES_SHAPE.begin(), ROUTE_LANES_SHAPE.end()), this->now(), lifetime,
-      {0.8, 0.8, 0.8, 0.8}, "base_link", true);
+      {0.8, 0.8, 0.8, 0.8}, "map", true);
     pub_route_marker_->publish(route_markers);
   }
 
   if (debug_params_.publish_debug_map) {
     auto lifetime = rclcpp::Duration::from_seconds(0.2);
     auto lane_markers = utils::create_lane_marker(
-      input_data_map["lanes"], std::vector<long>(LANES_SHAPE.begin(), LANES_SHAPE.end()),
-      this->now(), lifetime, {0.1, 0.1, 0.7, 0.8}, "base_link", true);
+      transforms_.first, input_data_map["lanes"],
+      std::vector<long>(LANES_SHAPE.begin(), LANES_SHAPE.end()), this->now(), lifetime,
+      {0.1, 0.1, 0.7, 0.8}, "map", true);
     pub_lane_marker_->publish(lane_markers);
   }
 }


### PR DESCRIPTION
I fixed the method of route construction in the training code.

https://github.com/tier4/Diffusion-Planner/blob/513d7f06cd9839250cc944188b5ece06c90eb013/diffusion_planner_ros/diffusion_planner_ros/diffusion_planner_node.py#L298-L309

But I forgot to change `mask_range`, so the route is cut by 100m.

https://github.com/tier4/Diffusion-Planner/blob/513d7f06cd9839250cc944188b5ece06c90eb013/diffusion_planner_ros/diffusion_planner_ros/diffusion_planner_node.py#L315

I think I will change it again in the near future, but for now, 100m from base_link is the best fit for the learning situation.