### PR TITLE
feat: remove onnxruntime dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,20 +61,6 @@ else()
   set(CUDNN_AVAIL OFF)
 endif()
 
-# ONNX Runtime (your existing)
-option(ONNXRUNTIME_DIR "Path to ONNX Runtime install root" "$ENV{HOME}/onnxruntime-linux-x64-gpu-1.20.1")
-set(ONNXRUNTIME_INCLUDE_DIR "${ONNXRUNTIME_DIR}/include")
-set(ONNXRUNTIME_LIB "${ONNXRUNTIME_DIR}/lib/libonnxruntime.so")
-
-set(ONNXRUNTIME_ROOT "$ENV{HOME}/onnxruntime-linux-x64-gpu-1.20.1")
-set(ONNXRUNTIME_INCLUDE_DIR "${ONNXRUNTIME_ROOT}/include")
-set(ONNXRUNTIME_LIB "${ONNXRUNTIME_ROOT}/lib/libonnxruntime.so")
-
-include_directories(
-  include
-  ${ONNXRUNTIME_INCLUDE_DIR}
-)
-
 # Add compile option to suppress deprecation warnings (optional)
 add_compile_options(-Wno-deprecated-declarations)
 
@@ -92,10 +78,6 @@ ament_auto_add_library(autoware_diffusion_planner_component SHARED
   src/utils/marker_utils.cpp
 )
 
-# Link libraries for ONNX Runtime, CUDA, TensorRT as available
-target_link_libraries(autoware_diffusion_planner_component
-  ${ONNXRUNTIME_LIB}
-)
 
 if(TRT_AVAIL AND CUDA_AVAIL)
   target_include_directories(autoware_diffusion_planner_component PUBLIC

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ It is implemented as a ROS 2 component node, making it easy to integrate into Au
 
 ### Dependencies
 
-- [ONNX Runtime](https://onnxruntime.ai/) (see `CMakeLists.txt` for version and path)
 - Autoware Universe packages
 - Eigen3
 - Lanelet2

--- a/config/diffusion_planner.param.yaml
+++ b/config/diffusion_planner.param.yaml
@@ -2,7 +2,6 @@
   ros__parameters:
     onnx_model_path: ""
     args_path: ""
-    backend: "TENSORRT" # Options: "TENSORRT", "ONNXRUNTIME"
     plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
     build_only: false
     planning_frequency_hz: 10.0

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -58,7 +58,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
-#include <onnxruntime_cxx_api.h>
 
 #include <memory>
 #include <optional>
@@ -101,7 +100,6 @@ struct DiffusionPlannerParams
 {
   std::string model_path;
   std::string args_path;
-  std::string backend;
   std::string plugins_path;
   bool build_only;
   double planning_frequency_hz;
@@ -191,12 +189,6 @@ public:
   void init_pointers();
 
   /**
-   * @brief Load ONNX model from file.
-   * @param model_path Path to the ONNX model file.
-   */
-  void load_model(const std::string & model_path);
-
-  /**
    * @brief Load the TensorRT engine from the specified model path.
    * This function sets up the TensorRT engine with the required input and output shapes.
    * It also initializes the TrtConvCalib for calibration if needed.
@@ -215,13 +207,6 @@ public:
    * @param predictions Output from the model.
    */
   void publish_predictions(const std::vector<float> & predictions) const;
-
-  /**
-   * @brief Run inference on input data and return predictions.
-   * @param input_data_map Input data for the model.
-   * @return Optional vector of ONNX model outputs.
-   */
-  std::vector<float> do_inference(InputDataMap & input_data_map);
 
   /**
    * @brief Run inference on input data output is stored on member output_d_.
@@ -250,13 +235,6 @@ public:
 
   // current state
   Odometry ego_kinematic_state_;
-
-  // onnxruntime
-  OrtCUDAProviderOptions cuda_options_;
-  Ort::Env env_;
-  Ort::SessionOptions session_options_;
-  Ort::Session session_;
-  Ort::AllocatorWithDefaultOptions allocator_;
 
   // TensorRT
   std::unique_ptr<TrtConvCalib> trt_common_;

--- a/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
+++ b/include/autoware/diffusion_planner/postprocessing/postprocessing_utils.hpp
@@ -16,7 +16,6 @@
 #define AUTOWARE__DIFFUSION_PLANNER__POSPROCESSING__POSPROCESSING_UTILS_HPP
 
 #include "autoware/diffusion_planner/conversion/agent.hpp"
-#include "onnxruntime_cxx_api.h"
 
 #include <Eigen/Dense>
 #include <rclcpp/rclcpp.hpp>


### PR DESCRIPTION
Since Autoware does not support onnxruntime by default and the TensorRT implementation works properly at a higher frequency, the onnxruntime package dependency is removed.