### PR TITLE
fix: critical bugs and add refactoring in diffusion_planner

### DIFF
--- a/include/autoware/diffusion_planner/constants.hpp
+++ b/include/autoware/diffusion_planner/constants.hpp
@@ -1,0 +1,52 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__CONSTANTS_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__CONSTANTS_HPP_
+
+namespace autoware::diffusion_planner::constants
+{
+
+// Velocity thresholds
+constexpr float MOVING_VELOCITY_THRESHOLD_MPS = 0.2f;
+
+// Time constants
+constexpr double PREDICTION_TIME_STEP_S = 0.1;
+constexpr double TIMER_PERIOD_S = 0.2;
+constexpr int LOG_THROTTLE_INTERVAL_MS = 5000;
+
+// Geometric constants
+constexpr float LANE_MASK_RANGE_M = 100.0f;
+constexpr double BACKWARD_PATH_LENGTH_M = 0.0;
+constexpr double FORWARD_PATH_LENGTH_M = 100.0;
+
+// LaneletConverter parameters
+struct LaneletConverterParams
+{
+  static constexpr int MAX_LANELETS = 100;
+  static constexpr int MAX_POINTS_PER_LANE = 20;
+  static constexpr double SEARCH_RADIUS_M = 100.0;
+};
+
+// Visualization parameters
+struct VisualizationParams
+{
+  static constexpr double DEBUG_MARKER_LIFETIME_S = 0.2;
+  static constexpr float ROUTE_MARKER_ALPHA = 0.8f;
+  static constexpr float MAP_MARKER_ALPHA = 0.8f;
+};
+
+}  // namespace autoware::diffusion_planner::constants
+
+#endif  // AUTOWARE__DIFFUSION_PLANNER__CONSTANTS_HPP_

--- a/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -167,6 +167,7 @@ class DiffusionPlanner : public rclcpp::Node
 {
 public:
   explicit DiffusionPlanner(const rclcpp::NodeOptions & options);
+  ~DiffusionPlanner();
   /**
    * @brief Initialize and declare node parameters.
    */

--- a/src/conversion/ego.cpp
+++ b/src/conversion/ego.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/diffusion_planner/conversion/ego.hpp"
 
+#include "autoware/diffusion_planner/constants.hpp"
+
 namespace autoware::diffusion_planner
 {
 EgoState::EgoState(
@@ -24,8 +26,7 @@ EgoState::EgoState(
   const auto & ang = kinematic_state_msg.twist.twist.angular;
 
   const float linear_vel = std::hypot(lin.x, lin.y);
-  constexpr float moving_velocity_threshold_mps{0.2};
-  if (linear_vel < moving_velocity_threshold_mps) {
+  if (linear_vel < constants::MOVING_VELOCITY_THRESHOLD_MPS) {
     yaw_rate_ = 0.0f;
     steering_angle_ = 0.0f;
   } else {

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -167,8 +167,9 @@ Eigen::MatrixXf get_prediction_matrix(
                           ", tensor_rows=" + std::to_string(tensor_data.rows()));
   }
   
-  Eigen::MatrixXf prediction_matrix =
-    tensor_data.block(start_row, 0, rows, cols);
+  // Extract and copy the block to ensure we have a proper matrix, not just a view
+  Eigen::MatrixXf prediction_matrix = 
+    tensor_data.block(start_row, 0, rows, cols).eval();
 
   // Copy only the relevant part
   prediction_matrix.transposeInPlace();

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -133,7 +133,15 @@ Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> get_tensor
   Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data(
     batch_size * agent_size * rows, cols);
   tensor_data.setZero();
-  std::memcpy(tensor_data.data(), prediction.data(), tensor_data.size() * sizeof(float));
+  
+  // Ensure prediction has enough data
+  const size_t required_size = tensor_data.size();
+  if (prediction.size() < required_size) {
+    throw std::runtime_error("Prediction vector size (" + std::to_string(prediction.size()) + 
+                           ") is smaller than required (" + std::to_string(required_size) + ")");
+  }
+  
+  std::memcpy(tensor_data.data(), prediction.data(), required_size * sizeof(float));
   return tensor_data;
 }
 
@@ -151,8 +159,16 @@ Eigen::MatrixXf get_prediction_matrix(
 
   Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> tensor_data =
     get_tensor_data(prediction);
+  // Validate indices before accessing block
+  const long start_row = batch * agent_size * rows + agent * rows;
+  if (start_row < 0 || start_row + rows > tensor_data.rows()) {
+    throw std::out_of_range("Invalid block access: start_row=" + std::to_string(start_row) + 
+                          ", rows=" + std::to_string(rows) + 
+                          ", tensor_rows=" + std::to_string(tensor_data.rows()));
+  }
+  
   Eigen::MatrixXf prediction_matrix =
-    tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
+    tensor_data.block(start_row, 0, rows, cols);
 
   // Copy only the relevant part
   prediction_matrix.transposeInPlace();

--- a/src/preprocessing/preprocessing_utils.cpp
+++ b/src/preprocessing/preprocessing_utils.cpp
@@ -45,7 +45,12 @@ void normalize_input_data(InputDataMap & input_data_map, const NormalizationMap 
       for (size_t col = 0; col < cols; ++col) {
         float m = (mean.size() == 1) ? mean[0] : mean[col];
         float s = (std_dev.size() == 1) ? std_dev[0] : std_dev[col];
-        data[offset + col] = (data[offset + col] - m) / s;
+        // Prevent division by zero
+        if (std::abs(s) < std::numeric_limits<float>::epsilon()) {
+          data[offset + col] = 0.0f;  // or keep unchanged
+        } else {
+          data[offset + col] = (data[offset + col] - m) / s;
+        }
       }
     }
   };

--- a/src/preprocessing/preprocessing_utils.cpp
+++ b/src/preprocessing/preprocessing_utils.cpp
@@ -47,10 +47,9 @@ void normalize_input_data(InputDataMap & input_data_map, const NormalizationMap 
         float s = (std_dev.size() == 1) ? std_dev[0] : std_dev[col];
         // Prevent division by zero
         if (std::abs(s) < std::numeric_limits<float>::epsilon()) {
-          data[offset + col] = 0.0f;  // or keep unchanged
-        } else {
-          data[offset + col] = (data[offset + col] - m) / s;
+          throw std::runtime_error("Standard deviation is zero, cannot normalize data");
         }
+        data[offset + col] = (data[offset + col] - m) / s;
       }
     }
   };

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -28,22 +28,18 @@ std::pair<Eigen::Matrix4f, Eigen::Matrix4f> get_transform_matrix(
   double y = msg.pose.pose.position.y;
   double z = msg.pose.pose.position.z;
 
-  // Extract orientation
-  double qx = msg.pose.pose.orientation.x;
-  double qy = msg.pose.pose.orientation.y;
-  double qz = msg.pose.pose.orientation.z;
-  double qw = msg.pose.pose.orientation.w;
-
   // Create Eigen quaternion and normalize it just in case
-  Eigen::Quaternionf q(qw, qx, qy, qz);
-  
-  // Check if quaternion is valid (non-zero)
-  if (q.norm() < std::numeric_limits<float>::epsilon()) {
-    // Use identity quaternion if invalid
-    q = Eigen::Quaternionf::Identity();
-  } else {
-    q.normalize();
-  }
+  Eigen::Quaternionf q = std::invoke([&msg]() -> Eigen::Quaternionf {
+    double qx = msg.pose.pose.orientation.x;
+    double qy = msg.pose.pose.orientation.y;
+    double qz = msg.pose.pose.orientation.z;
+    double qw = msg.pose.pose.orientation.w;
+
+    // Create Eigen quaternion and normalize it just in case
+    Eigen::Quaternionf q(qw, qx, qy, qz);
+    return (q.norm() < std::numeric_limits<float>::epsilon()) ? Eigen::Quaternionf::Identity()
+                                                              : q.normalized();
+  });
 
   // Rotation matrix (3x3)
   Eigen::Matrix3f R = q.toRotationMatrix();

--- a/tests/postprocessing_utils_test.cpp
+++ b/tests/postprocessing_utils_test.cpp
@@ -62,15 +62,23 @@ TEST(PostprocessingUtilsTest, TransformOutputMatrixNoTranslation)
 
 TEST(PostprocessingUtilsTest, GetTensorDataCopiesData)
 {
-  std::vector<float> data{1, 2, 3, 4, 5, 6};
   std::vector<int64_t> shape{1, 1, 2, 3};
 
-  auto mat = postprocess::get_tensor_data(data);
   constexpr auto prediction_shape = OUTPUT_SHAPE;
   auto batch_size = prediction_shape[0];
   auto agent_size = prediction_shape[1];
   auto rows = prediction_shape[2];
   auto cols = prediction_shape[3];
+
+  std::vector<float> data(batch_size * agent_size * rows * cols, 0.0f);
+  data[0] = 1.0f;
+  data[1] = 2.0f;
+  data[2] = 3.0f;
+  data[3] = 4.0f;
+  data[4] = 5.0f;
+  data[5] = 6.0f;
+  data[6] = 7.0f;
+  auto mat = postprocess::get_tensor_data(data);
 
   ASSERT_EQ(mat.rows(), batch_size * agent_size * rows);
   ASSERT_EQ(mat.cols(), cols);
@@ -81,9 +89,13 @@ TEST(PostprocessingUtilsTest, GetTensorDataCopiesData)
 
 TEST(PostprocessingUtilsTest, GetPredictionMatrixTransformsCorrectly)
 {
-  constexpr int rows = 3;
-  constexpr int cols = OUTPUT_T;  // Use the actual OUTPUT_T value
-  std::vector<float> data(rows * cols, 0.0f);
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+  auto batch_size = prediction_shape[0];
+  auto agent_size = prediction_shape[1];
+  auto rows = prediction_shape[2];
+  auto cols = prediction_shape[3];
+
+  std::vector<float> data(batch_size * agent_size * rows * cols, 0.0f);
   // Fill with some values for checking
   for (int i = 0; i < rows * cols; ++i) data[i] = static_cast<float>(i);
 
@@ -94,14 +106,12 @@ TEST(PostprocessingUtilsTest, GetPredictionMatrixTransformsCorrectly)
   transform(1, 3) = 2.0f;
 
   auto mat = postprocess::get_prediction_matrix(data, transform, 0, 0);
-  constexpr auto prediction_shape = OUTPUT_SHAPE;
 
   auto expected_rows = prediction_shape[2];
   auto expected_cols = prediction_shape[3];
 
   ASSERT_EQ(mat.rows(), expected_rows);
   ASSERT_EQ(mat.cols(), expected_cols);
-  // Optionally, check a few values to ensure transformation occurred
 }
 
 TEST(PostprocessingUtilsTest, GetTrajectoryFromPredictionMatrixWorks)
@@ -121,19 +131,18 @@ TEST(PostprocessingUtilsTest, GetTrajectoryFromPredictionMatrixWorks)
 
 TEST(PostprocessingUtilsTest, CreateTrajectoryAndMultipleTrajectories)
 {
-  constexpr int batch = 1;
-  constexpr int agent = 2;
-  constexpr int rows = 2;
-  constexpr int cols = OUTPUT_T;
-  std::vector<float> data(batch * agent * rows * cols, 0.0f);
+  constexpr auto prediction_shape = OUTPUT_SHAPE;
+  auto batch_size = prediction_shape[0];
+  auto agent_size = prediction_shape[1];
+  auto rows = prediction_shape[2];
+  auto cols = prediction_shape[3];
+  std::vector<float> data(batch_size * agent_size * rows * cols, 0.0f);
   // Fill with some values for checking
   for (size_t i = 0; i < data.size(); ++i) data[i] = static_cast<float>(i);
 
-  std::vector<int64_t> shape{batch, agent, rows, cols};
+  std::vector<int64_t> shape{batch_size, agent_size, rows, cols};
   Eigen::Matrix4f transform = Eigen::Matrix4f::Identity();
   rclcpp::Time stamp(123, 0);
-
-  constexpr auto prediction_shape = OUTPUT_SHAPE;
 
   auto expected_trajs = prediction_shape[1];
   auto expected_points = prediction_shape[2];

--- a/tests/pre_processing_utils_test.cpp
+++ b/tests/pre_processing_utils_test.cpp
@@ -106,10 +106,8 @@ TEST_F(PreprocessingUtilsTest, HandlesZeroStdDev)
   normalization_map["f"] = {{5.0f, 5.0f}, {0.0f, 0.0f}};
 
   // Should not throw, but result should be inf or nan depending on implementation
-  preprocess::normalize_input_data(input_data_map, normalization_map);
-
-  EXPECT_TRUE(std::isfinite(input_data_map["f"][0]) || std::isnan(input_data_map["f"][0]));
-  EXPECT_TRUE(std::isfinite(input_data_map["f"][1]) || std::isnan(input_data_map["f"][1]));
+  EXPECT_THROW(
+    preprocess::normalize_input_data(input_data_map, normalization_map), std::runtime_error);
 }
 
 TEST_F(PreprocessingUtilsTest, HandlesSingleMeanStdForAllCols)


### PR DESCRIPTION
- Fix CUDA resource leak by adding destructor to clean up stream
- Add CUDA error checking for all memory operations
- Fix division by zero in normalization when std_dev is zero
- Add integer overflow protection in create_float_data
- Add bounds checking in postprocessing tensor operations
- Add quaternion validation before normalization
- Replace complex shared_ptr usage with std::vector for bool array
- Create constants.hpp to replace magic numbers throughout codebase
- Update code to use named constants instead of hardcoded values

These fixes address memory leaks, potential crashes, and improve code maintainability.

🤖 Generated with [Claude Code](https://claude.ai/code)