### PR TITLE
refactor: use named constants for output tensor dimensions

### DIFF
--- a/include/autoware/diffusion_planner/dimensions.hpp
+++ b/include/autoware/diffusion_planner/dimensions.hpp
@@ -45,10 +45,10 @@ inline constexpr long SPEED_LIMIT = 12;
 inline constexpr long LANE_ID = 13;
 
 inline constexpr long OUTPUT_T = 80;  // Output timestamp number
-inline constexpr long OUT_X = 0;      // Output timestamp number
-inline constexpr long OUT_Y = 1;      // Output timestamp number
-inline constexpr long OUT_COS = 2;    // Output timestamp number
-inline constexpr long OUT_SIN = 3;    // Output timestamp number
+inline constexpr long OUTPUT_X = 0;    // Output tensor X-coordinate index
+inline constexpr long OUTPUT_Y = 1;    // Output tensor Y-coordinate index
+inline constexpr long OUTPUT_COS = 2;  // Output tensor cosine (orientation) index
+inline constexpr long OUTPUT_SIN = 3;  // Output tensor sine (orientation) index
 
 inline constexpr std::array<long, 4> OUTPUT_SHAPE = {1, 33, 80, 4};
 

--- a/include/autoware/diffusion_planner/dimensions.hpp
+++ b/include/autoware/diffusion_planner/dimensions.hpp
@@ -45,6 +45,11 @@ inline constexpr long SPEED_LIMIT = 12;
 inline constexpr long LANE_ID = 13;
 
 inline constexpr long OUTPUT_T = 80;  // Output timestamp number
+inline constexpr long OUT_X = 0;      // Output timestamp number
+inline constexpr long OUT_Y = 1;      // Output timestamp number
+inline constexpr long OUT_COS = 2;    // Output timestamp number
+inline constexpr long OUT_SIN = 3;    // Output timestamp number
+
 inline constexpr std::array<long, 4> OUTPUT_SHAPE = {1, 33, 80, 4};
 
 inline constexpr std::array<long, 2> EGO_CURRENT_STATE_SHAPE = {1, 10};

--- a/include/autoware/diffusion_planner/dimensions.hpp
+++ b/include/autoware/diffusion_planner/dimensions.hpp
@@ -44,7 +44,7 @@ inline constexpr long TRAFFIC_LIGHT_WHITE = 11;
 inline constexpr long SPEED_LIMIT = 12;
 inline constexpr long LANE_ID = 13;
 
-inline constexpr long OUTPUT_T = 80;  // Output timestamp number
+inline constexpr long OUTPUT_T = 80;   // Output timestamp number
 inline constexpr long OUTPUT_X = 0;    // Output tensor X-coordinate index
 inline constexpr long OUTPUT_Y = 1;    // Output tensor Y-coordinate index
 inline constexpr long OUTPUT_COS = 2;  // Output tensor cosine (orientation) index

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -200,10 +200,10 @@ Trajectory get_trajectory_from_prediction_matrix(
     p.time_from_start.sec = static_cast<int>(dt * static_cast<double>(row));
     p.time_from_start.nanosec =
       static_cast<int>((dt * static_cast<double>(row) - p.time_from_start.sec) * 1e9);
-    p.pose.position.x = prediction_matrix(row, OUT_X);
-    p.pose.position.y = prediction_matrix(row, OUT_Y);
+    p.pose.position.x = prediction_matrix(row, OUTPUT_X);
+    p.pose.position.y = prediction_matrix(row, OUTPUT_Y);
     p.pose.position.z = ego_position.z();
-    auto yaw = std::atan2(prediction_matrix(row, OUT_SIN), prediction_matrix(row, OUT_COS));
+    auto yaw = std::atan2(prediction_matrix(row, OUTPUT_SIN), prediction_matrix(row, OUTPUT_COS));
     yaw = static_cast<float>(autoware_utils::normalize_radian(yaw));
     p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
     auto distance = std::hypot(p.pose.position.x - prev_x, p.pose.position.y - prev_y);
@@ -247,9 +247,9 @@ std::vector<Trajectory> create_multiple_trajectories(
         tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
 
       prediction_matrix.transposeInPlace();
-      postprocess::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, OUT_X, true);
+      postprocess::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, OUTPUT_X, true);
       postprocess::transform_output_matrix(
-        transform_ego_to_map, prediction_matrix, 0, OUT_COS, false);
+        transform_ego_to_map, prediction_matrix, 0, OUTPUT_COS, false);
       prediction_matrix.transposeInPlace();
       agent_trajectories.push_back(
         get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp));

--- a/src/postprocessing/postprocessing_utils.cpp
+++ b/src/postprocessing/postprocessing_utils.cpp
@@ -200,10 +200,10 @@ Trajectory get_trajectory_from_prediction_matrix(
     p.time_from_start.sec = static_cast<int>(dt * static_cast<double>(row));
     p.time_from_start.nanosec =
       static_cast<int>((dt * static_cast<double>(row) - p.time_from_start.sec) * 1e9);
-    p.pose.position.x = prediction_matrix(row, 0);
-    p.pose.position.y = prediction_matrix(row, 1);
+    p.pose.position.x = prediction_matrix(row, OUT_X);
+    p.pose.position.y = prediction_matrix(row, OUT_Y);
     p.pose.position.z = ego_position.z();
-    auto yaw = std::atan2(prediction_matrix(row, 3), prediction_matrix(row, 2));
+    auto yaw = std::atan2(prediction_matrix(row, OUT_SIN), prediction_matrix(row, OUT_COS));
     yaw = static_cast<float>(autoware_utils::normalize_radian(yaw));
     p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
     auto distance = std::hypot(p.pose.position.x - prev_x, p.pose.position.y - prev_y);
@@ -247,8 +247,9 @@ std::vector<Trajectory> create_multiple_trajectories(
         tensor_data.block(batch * agent_size * rows + agent * rows, 0, rows, cols);
 
       prediction_matrix.transposeInPlace();
-      postprocess::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 0, true);
-      postprocess::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, 2, false);
+      postprocess::transform_output_matrix(transform_ego_to_map, prediction_matrix, 0, OUT_X, true);
+      postprocess::transform_output_matrix(
+        transform_ego_to_map, prediction_matrix, 0, OUT_COS, false);
       prediction_matrix.transposeInPlace();
       agent_trajectories.push_back(
         get_trajectory_from_prediction_matrix(prediction_matrix, transform_ego_to_map, stamp));


### PR DESCRIPTION
- Add OUT_X, OUT_Y, OUT_COS, OUT_SIN constants in dimensions.hpp for better code readability
- Replace magic numbers with named constants in postprocessing_utils.cpp
- Improves maintainability by making the purpose of array indices explicit

🤖 Generated with [Claude Code](https://claude.ai/code)